### PR TITLE
Add emitter for datepicker confirm

### DIFF
--- a/src/dialog.component.ts
+++ b/src/dialog.component.ts
@@ -98,6 +98,7 @@ export class DialogComponent implements OnInit, OnDestroy {
     public confirm( close: boolean ): void {
         this.returnSelectedMoment();
         if (close === true) {
+            this.confirmSelectedMoment();
             this.cancelDialog();
         } else {
             this.dialogType = this.service.dtDialogType;
@@ -124,6 +125,12 @@ export class DialogComponent implements OnInit, OnDestroy {
         } else {
             this.confirm(false);
         }
+    }
+
+    private confirmSelectedMoment(): void {
+        let m = this.selectedMoment || this.now;
+        let selectedM = this.service.parseToReturnObjectType(m);
+        this.directiveInstance.momentConfirmed(selectedM);
     }
 
     private returnSelectedMoment(): void {

--- a/src/picker.directive.ts
+++ b/src/picker.directive.ts
@@ -18,6 +18,7 @@ export class DateTimePickerDirective implements OnInit, OnChanges {
 
     @Input('dateTimePicker') dateTimePicker: any;
     @Output('dateTimePickerChange') dateTimePickerChange = new EventEmitter<any>(true);
+    @Output('dateTimePickerConfirm') dateTimePickerConfirm = new EventEmitter<any>(true);
     @Input() locale: string = 'en';
     @Input() viewFormat: string = 'll';
     @Input() returnObject: string = 'js';
@@ -54,6 +55,10 @@ export class DateTimePickerDirective implements OnInit, OnChanges {
 
     public onClick(): void {
         this.openDialog();
+    }
+
+    public momentConfirmed( value: any) {
+        this.dateTimePickerConfirm.emit(value);
     }
 
     public momentChanged( value: any ) {


### PR DESCRIPTION
I have a need to submit a new date value without submitting a form. The current datetime picker does not provide an event when the datetime has been 'Confirmed' by the user.

I added a dateTimePickerConfirm EventEmitter to emit the current date value when the datetime picker closes, if the user has selected 'Confirm'.