### PR TITLE
Style. Fixing greedy css class prefix

### DIFF
--- a/src/sass/picker.scss
+++ b/src/sass/picker.scss
@@ -25,7 +25,7 @@ $blue: #0070ba;
 }
 */
 
-[class^="icon-"]:before, [class*=" icon-"]:before {
+[class^="icon-owl-"]:before, [class*=" icon-owl-"]:before {
   font-family: "fontello";
   font-style: normal;
   font-weight: normal;


### PR DESCRIPTION
Related to 
#126: Not prefixed icons overwriting app-styles 
#127: Prefixed icon related classes and adjusted affected markup
#148: Can't Use FontAwesome Icon

I know you did just pushed a fix to this few days ago in 39a56fa, but you left out this bit:

`[class^="icon-"]:before, [class*=" icon-"]:before  `

which i think was the main cause of an issue. Taking you latest commit related to this issue, it makes sense to adjust this selector as well. 