### PR TITLE
Added now button when buttons are available

### DIFF
--- a/src/picker.component.html
+++ b/src/picker.component.html
@@ -170,6 +170,9 @@
             <div class="owl-dateTime-btn owl-corner-bottomLeft owl-dateTime-btnConfirm"
                  (click)="onConfirmClick($event)">Confirm
             </div>
+            <div class="owl-dateTime-btn owl-dateTime-btnNow" (click)="onNowClick($event)">
+                {{locale.btnNow}}
+            </div>
             <div class="owl-dateTime-btn owl-corner-bottomRight owl-dateTime-btnClose" (click)="onCloseClick($event)">
                 Close
             </div>

--- a/src/picker.component.ts
+++ b/src/picker.component.ts
@@ -572,17 +572,12 @@ export class DateTimePickerComponent implements OnInit, OnDestroy, ControlValueA
      * */
     public onNowClick( event: any ): void {
         // Set current date
-
-        console.log(this.value);
-
         if(this.value instanceof Array){
             this.value = [];
             this.value[0] = new Date();
         } else {
             this.value = new Date();
         }
-
-        console.log(this.value);
 
         // Update the calendar
         this.updateCalendar(this.value);

--- a/src/picker.component.ts
+++ b/src/picker.component.ts
@@ -48,6 +48,7 @@ export interface LocaleSettings {
     monthNames: string[];
     monthNamesShort: string[];
     dateFns: any;
+    btnNow: string;
 }
 
 export enum DialogType {
@@ -379,7 +380,8 @@ export class DateTimePickerComponent implements OnInit, OnDestroy, ControlValueA
         dayNamesShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
         monthNames: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
         monthNamesShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
-        dateFns: null
+        dateFns: null,
+        btnNow: "Now"
     };
     private dialogClick: boolean;
     private documentClickListener: Function;
@@ -558,6 +560,34 @@ export class DateTimePickerComponent implements OnInit, OnDestroy, ControlValueA
             value: this.value
         });
         this.hide(event);
+        event.stopPropagation();
+        event.preventDefault();
+        return;
+    }
+    
+    /**
+     * Handle click event on the now button
+     * @param {any} event
+     * @return {void}
+     * */
+    public onNowClick( event: any ): void {
+        // Set current date
+
+        console.log(this.value);
+
+        if(this.value instanceof Array){
+            this.value = [];
+            this.value[0] = new Date();
+        } else {
+            this.value = new Date();
+        }
+
+        console.log(this.value);
+
+        // Update the calendar
+        this.updateCalendar(this.value);
+        this.updateTimer(this.value);
+
         event.stopPropagation();
         event.preventDefault();
         return;


### PR DESCRIPTION
Feature: #118 , #122 

Added a now button to the calendar:
![image](https://user-images.githubusercontent.com/13018117/33229300-b6b3c746-d1cc-11e7-994c-c55e2d4669ee.png)

When the calendar is in single mode, the 'Now' button set the selected date to now. 
When in multiple mode, all dates are cleared and a new date will be added to the array of dates.
When in range mode, the first date will be set to now.

To be ahead of PR #199, it is also possible with this PR to localize the now button