### PR TITLE
Set time on blur instead of input event

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Angular Date Time Picker
 
 Breaking Changes
 -------
+ - Time is set on blur instead on input event.
  - The picker has been updated for Angular 7+ apps.
 
 Description

--- a/src/date-time/timer-box.component.html
+++ b/src/date-time/timer-box.component.html
@@ -20,7 +20,7 @@
 <label class="owl-dt-timer-content">
     <input class="owl-dt-timer-input" maxlength="2"
            [value]="displayValue | numberFixedLen : 2"
-           (input)="handleInputChange(valueInput.value)" #valueInput>
+           (blur)="handleInputChange(valueInput.value)" #valueInput>
     <span class="owl-hidden-accessible">{{inputLabel}}</span>
 </label>
 <button class="owl-dt-control-button owl-dt-control-arrow-button"

--- a/src/date-time/timer-box.component.ts
+++ b/src/date-time/timer-box.component.ts
@@ -75,7 +75,6 @@ export class OwlTimerBoxComponent implements OnInit, OnDestroy {
 
     public ngOnInit() {
         this.inputStreamSub = this.inputStream.pipe(
-            debounceTime(500),
             distinctUntilChanged()
         ).subscribe(( val: string ) => {
             if (val) {


### PR DESCRIPTION
User can't change time by keyboard, because every time we delete one character, date is updated and input field value is changed, and we got additional '0' in front of the remaining number.